### PR TITLE
Make APP_ROOT and INFRASTRUCTURE_ROOT configurable via env vars

### DIFF
--- a/backup/run-backup.sh
+++ b/backup/run-backup.sh
@@ -35,6 +35,9 @@ EXCLUDES="$SCRIPT_DIR/exclude-list.txt"
 RESTORE_MD="$SCRIPT_DIR/RESTORE.md"
 LOG_FILE=/var/log/backup/run.log
 
+APP_ROOT="${APP_ROOT:-/home/dhughes/apps}"
+INFRASTRUCTURE_ROOT="${INFRASTRUCTURE_ROOT:-/home/dhughes/infrastructure}"
+
 NOTIFY="$LIB_DIR/notify.sh"
 HC_URL_FILE=/root/.healthchecks-url
 
@@ -152,8 +155,8 @@ run_phase "Phase 6 (Restic backup)" \
     --exclude-file "$EXCLUDES" \
     --exclude-caches \
     "$STAGING" \
-    /home/dhughes/apps \
-    /home/dhughes/infrastructure \
+    "$APP_ROOT" \
+    "$INFRASTRUCTURE_ROOT" \
     /etc/ssh \
     /etc/ddclient.conf \
     /etc/crypttab \

--- a/backup/run-backup.sh
+++ b/backup/run-backup.sh
@@ -35,7 +35,7 @@ EXCLUDES="$SCRIPT_DIR/exclude-list.txt"
 RESTORE_MD="$SCRIPT_DIR/RESTORE.md"
 LOG_FILE=/var/log/backup/run.log
 
-APP_ROOT="${APP_ROOT:-/home/dhughes/apps}"
+APPS_ROOT="${APPS_ROOT:-/home/dhughes/apps}"
 INFRASTRUCTURE_ROOT="${INFRASTRUCTURE_ROOT:-/home/dhughes/infrastructure}"
 
 NOTIFY="$LIB_DIR/notify.sh"
@@ -155,7 +155,7 @@ run_phase "Phase 6 (Restic backup)" \
     --exclude-file "$EXCLUDES" \
     --exclude-caches \
     "$STAGING" \
-    "$APP_ROOT" \
+    "$APPS_ROOT" \
     "$INFRASTRUCTURE_ROOT" \
     /etc/ssh \
     /etc/ddclient.conf \


### PR DESCRIPTION
## Summary

Stage 2 prep for the upcoming LUKS partition migration on the home server, which will move `/home/dhughes/apps` to `/mnt/data/apps` and `/home/dhughes/infrastructure` to `/mnt/data/infrastructure`.

By introducing env vars in `backup/run-backup.sh` with the current paths as defaults, deploying this PR changes nothing in production. On migration day, the new locations become a config change (env vars set in `/etc/cron.d/backup` or in the script's environment) rather than a code change made under pressure during the maintenance window.

## Changes

- Added `APP_ROOT` and `INFRASTRUCTURE_ROOT` to the config block at the top of `backup/run-backup.sh`, each defaulting to the current hardcoded path.
- Replaced the two hardcoded paths in the Phase 6 `restic backup` arguments with the new variables.
- `/home/dhughes/.ssh/authorized_keys` remains hardcoded - the user's `.ssh` directory stays on the unencrypted root partition during the migration.

## Test Plan

- [x] `bash -n backup/run-backup.sh` passes (syntax valid)
- [x] Visual diff inspection - defaults preserve current behavior
- [ ] On migration day: set `APP_ROOT` and `INFRASTRUCTURE_ROOT` in `/etc/cron.d/backup` (or wherever appropriate) to the new `/mnt/data/...` paths